### PR TITLE
BugFix

### DIFF
--- a/widget/view.html
+++ b/widget/view.html
@@ -30,7 +30,7 @@
                         </div>
                     </div>
                     <div class="card-content-fixed-height">
-                        <button type="button" class="btn btn-primary btn-sm"
+                        <button title="{{config.labelCTA}}" type="button" class="action-button btn btn-primary btn-sm list-action ng-binding text-overflow"
                             data-ng-click="openRecord(config.module, record['@id'].value)">
                             <i class="{{config.showIcon}} margin-right-sm"></i>{{config.labelCTA}}</button>
                     </div>


### PR DESCRIPTION
- 0883839 | If the button label is too bug in the widget config then on saving the text for button is not truncated

